### PR TITLE
chore(ci): add placeholder lint/build/test scripts for smoke checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "scripts": {
     "start-core": "concurrently -n auth,ledger,payments,api,worker,fraud,analytics,notif,web -c auto \"npm --workspace services/auth run dev\" \"npm --workspace services/core-ledger run dev\" \"npm --workspace services/core-payments run dev\" \"npm --workspace services/api-gateway run dev\" \"npm --workspace services/multistream-worker run dev\" \"npm --workspace services/fraud-mesh run dev\" \"npm --workspace services/analytics run dev\" \"npm --workspace services/notifications run dev\" \"npm --workspace apps/web run dev\"",
     "start-all": "concurrently -n all -c auto \"npm --workspace services/auth run dev\" \"npm --workspace services/core-ledger run dev\" \"npm --workspace services/core-payments run dev\" \"npm --workspace services/api-gateway run dev\" \"npm --workspace services/multistream-worker run dev\" \"npm --workspace services/fraud-mesh run dev\" \"npm --workspace services/analytics run dev\" \"npm --workspace services/notifications run dev\" \"npm --workspace apps/web run dev\"",
-    "autosave": "bash ./autosave.sh"
+    "autosave": "bash ./autosave.sh",
+    "lint": "echo Lint OK",
+    "build": "echo Build OK",
+    "test": "echo Test OK"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",


### PR DESCRIPTION
Adds minimal CI smoke scripts so PRs can run lint/build/test gates.

- lint: echo Lint OK
- build: echo Build OK
- test: echo Test OK

These will be replaced with real tooling (ESLint, build, Jest/Vitest) in upcoming PRs.
