### PR TITLE
ci: add CI / build workflow for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint
         run: npm run lint --if-present


### PR DESCRIPTION
This PR introduces a standardized GitHub Actions workflow for lint, build, and test.
Required for branch protection on main.
